### PR TITLE
docs: clarify roadmap items for performance and async/reactive APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,12 @@ If you discover any security issue, please see [SECURITY.md](SECURITY.md).
 
 ## 📅 Roadmap
 
-- [ ] v1.1 — Performance tests and possible improvements
-- [ ] v2.0 — Async API with reactive streams
+- [ ] v1.1 — Performance track: reproducible benchmarks + targeted optimizations
+- [ ] v2.0 — Async API with reactive streams (non-blocking/backpressure-friendly)
+- [ ] Resource streaming beyond local FS (classpath/JAR resources)
+- [ ] Universal source adapters (e.g., HTTP/HTTPS and pluggable providers)
+
+Longer-form future ideas are tracked in [docs/FUTURE_IDEAS.md](docs/FUTURE_IDEAS.md).
 
 ---
 

--- a/docs/FUTURE_IDEAS.md
+++ b/docs/FUTURE_IDEAS.md
@@ -11,37 +11,7 @@ It is intentionally not a strict task list yet — items can be refined later in
 
 ## Candidate directions
 
-### 1) Resource streaming support (non-local FS)
-
-**Goal:** extend `GlobPathFinder` so it can stream not only resources from the local filesystem,
-but also resources loaded through class/resource loaders.
-
-Potential targets:
-
-- Classpath resources from compiled artifacts.
-- Resources inside JAR files.
-- Other packaged resource containers where listing/streaming is possible.
-
-Expected result:
-
-- A unified API feeling similar to current filesystem traversal.
-- Reuse as much of existing filtering logic as possible (glob includes/excludes, extension filters, etc.).
-
-### 2) More universal source adapters
-
-**Goal:** evolve from a filesystem-first utility into a more universal path/resource discovery engine.
-
-Potential adapters:
-
-- HTTP/HTTPS source streaming (where applicable).
-- Other pluggable "source providers" for custom storage backends.
-
-Expected result:
-
-- Extensible architecture: one traversal/filtering pipeline, multiple source implementations.
-- Clear separation between source enumeration and filtering/matching stages.
-
-### 3) v1.1 performance track: benchmarks + targeted optimizations
+### 1) v1.1 performance track: benchmarks + targeted optimizations
 
 **What this means:** not "optimize blindly", but introduce measurable performance baselines and
 then improve hot spots that are proven by profiling and benchmark runs.
@@ -58,7 +28,7 @@ Expected result:
 - Performance regression visibility between releases.
 - Practical optimization roadmap with measurable gain (throughput/latency/memory).
 
-### 4) v2.0 async/reactive API
+### 2) v2.0 async/reactive API
 
 **What this means:** introduce a non-blocking style API for consuming traversal results as a stream
 with backpressure-friendly behavior, while keeping the current synchronous API available.
@@ -74,6 +44,36 @@ Expected result:
 - Better integration with reactive applications and pipelines.
 - Ability to process results as they appear, without waiting for full traversal completion.
 - Clear migration story: sync API remains stable, async API is additive.
+
+### 3) Resource streaming support (non-local FS)
+
+**Goal:** extend `GlobPathFinder` so it can stream not only resources from the local filesystem,
+but also resources loaded through class/resource loaders.
+
+Potential targets:
+
+- Classpath resources from compiled artifacts.
+- Resources inside JAR files.
+- Other packaged resource containers where listing/streaming is possible.
+
+Expected result:
+
+- A unified API feeling similar to current filesystem traversal.
+- Reuse as much of existing filtering logic as possible (glob includes/excludes, extension filters, etc.).
+
+### 4) More universal source adapters
+
+**Goal:** evolve from a filesystem-first utility into a more universal path/resource discovery engine.
+
+Potential adapters:
+
+- HTTP/HTTPS source streaming (where applicable).
+- Other pluggable "source providers" for custom storage backends.
+
+Expected result:
+
+- Extensible architecture: one traversal/filtering pipeline, multiple source implementations.
+- Clear separation between source enumeration and filtering/matching stages.
 
 ## Notes for future decomposition
 

--- a/docs/FUTURE_IDEAS.md
+++ b/docs/FUTURE_IDEAS.md
@@ -1,0 +1,86 @@
+# Future ideas and backlog
+
+This document is a lightweight backlog for product ideas and architectural directions.
+It is intentionally not a strict task list yet — items can be refined later into issues/milestones.
+
+## How to use this file
+
+- Capture ideas early before they are forgotten.
+- Keep entries short: intent, expected value, and rough implementation direction.
+- Move mature items into GitHub issues and release plans.
+
+## Candidate directions
+
+### 1) Resource streaming support (non-local FS)
+
+**Goal:** extend `GlobPathFinder` so it can stream not only resources from the local filesystem,
+but also resources loaded through class/resource loaders.
+
+Potential targets:
+
+- Classpath resources from compiled artifacts.
+- Resources inside JAR files.
+- Other packaged resource containers where listing/streaming is possible.
+
+Expected result:
+
+- A unified API feeling similar to current filesystem traversal.
+- Reuse as much of existing filtering logic as possible (glob includes/excludes, extension filters, etc.).
+
+### 2) More universal source adapters
+
+**Goal:** evolve from a filesystem-first utility into a more universal path/resource discovery engine.
+
+Potential adapters:
+
+- HTTP/HTTPS source streaming (where applicable).
+- Other pluggable "source providers" for custom storage backends.
+
+Expected result:
+
+- Extensible architecture: one traversal/filtering pipeline, multiple source implementations.
+- Clear separation between source enumeration and filtering/matching stages.
+
+### 3) v1.1 performance track: benchmarks + targeted optimizations
+
+**What this means:** not "optimize blindly", but introduce measurable performance baselines and
+then improve hot spots that are proven by profiling and benchmark runs.
+
+Focus areas:
+
+- Reproducible benchmark scenarios (small/medium/large trees, deep nesting, many globs).
+- Cost analysis for include/exclude matching and path normalization.
+- Memory pressure checks for large result sets.
+- Parallel traversal tuning and heuristics for thread usage.
+
+Expected result:
+
+- Performance regression visibility between releases.
+- Practical optimization roadmap with measurable gain (throughput/latency/memory).
+
+### 4) v2.0 async/reactive API
+
+**What this means:** introduce a non-blocking style API for consuming traversal results as a stream
+with backpressure-friendly behavior, while keeping the current synchronous API available.
+
+Possible directions:
+
+- Reactive Streams-compatible publisher (e.g., `Flow.Publisher<Path>`).
+- Async callback/subscriber-based consumption for incremental processing.
+- Configurable scheduler/executor model for traversal and emission.
+
+Expected result:
+
+- Better integration with reactive applications and pipelines.
+- Ability to process results as they appear, without waiting for full traversal completion.
+- Clear migration story: sync API remains stable, async API is additive.
+
+## Notes for future decomposition
+
+When converting these ideas into executable tasks, define:
+
+- API surface (minimal/non-breaking first).
+- Backward compatibility strategy.
+- Performance expectations and benchmarks.
+- Error handling model per source type.
+- Testing matrix for each provider/adapter.


### PR DESCRIPTION
### Motivation
- The roadmap items for performance and an async API were too terse and could be misinterpreted, so they were expanded to give concrete, actionable meaning. 
- The change follows the recent request to explicitly describe what “performance” and “async/reactive” can practically mean for the project.

### Description
- Added a `v1.1 performance track` section to `docs/FUTURE_IDEAS.md` that defines a benchmark-first approach, focus areas (benchmarks, profiling, memory, parallel traversal) and expected results. 
- Added a `v2.0 async/reactive API` section to `docs/FUTURE_IDEAS.md` that outlines non-blocking, backpressure-friendly directions and migration expectations (reactive publisher, async subscriber, configurable schedulers). 
- Updated the `README.md` roadmap wording to reference the expanded `docs/FUTURE_IDEAS.md` and to make the performance and async items more explicit.

### Testing
- Ran `mvn -q -DskipTests compile` which completed successfully to validate the repository builds after the documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c7b5f1548325b3499213a54a01e0)